### PR TITLE
Replace gulp-minify-html by gulp-htmlmin

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -41,8 +41,9 @@ module.exports = fountain.Base.extend({
         Object.assign(pkg.devDependencies, {
           'gulp-angular-filesort': '^1.1.1',
           'gulp-angular-templatecache': '^1.8.0',
-          'gulp-ng-annotate': '^1.1.0',
-          'gulp-insert': '^0.5.0'
+          'gulp-htmlmin': '^1.3.0',
+          'gulp-insert': '^0.5.0',
+          'gulp-ng-annotate': '^1.1.0'
         });
       }
 

--- a/generators/app/templates/gulp_tasks/partials.js
+++ b/generators/app/templates/gulp_tasks/partials.js
@@ -1,5 +1,5 @@
 const gulp = require('gulp');
-const minifyHtml = require('gulp-minify-html');
+const htmlmin = require('gulp-htmlmin');
 const angularTemplatecache = require('gulp-angular-templatecache');
 <% if (modules !== 'inject') { -%>
 const insert = require('gulp-insert');
@@ -11,11 +11,7 @@ gulp.task('partials', partials);
 
 function partials() {
   return gulp.src(conf.path.src('app/**/*.html'))
-    .pipe(minifyHtml({
-      empty: true,
-      spare: true,
-      quotes: true
-    }))
+    .pipe(htmlmin())
 <% if (js === 'typescript' && modules !== 'inject') { -%>
     .pipe(angularTemplatecache('templateCacheHtml.ts', {
 <% } else { -%>


### PR DESCRIPTION
Fix #5

To compare options:
- [minify-html options](https://github.com/Swaagie/minimize#options)
- [htmlmin options](https://github.com/kangax/html-minifier#options-quick-reference)

~~@Swiip I add gulp-htmlmin for each stack (Webpack or not). Task's gulp partial is used only for "inject"?~~

I found answer in code

```
if (this.props.framework === 'angular1') {
      this.copyTemplate(
        'gulp_tasks/partials.js',
        'gulp_tasks/partials.js',
        this.props
      );
    }
```
