### PR TITLE
Add CI configuration files

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -102,6 +102,9 @@ module.exports = fountain.Base.extend({
     this.composeWith(`fountain-gulp:git`, {options: {modules: this.options.modules}}, {
       local: require.resolve(`../git`)
     });
+    this.composeWith(`fountain-gulp:ci`, {options: {ci: this.options.ci}}, {
+      local: require.resolve(`../ci`)
+    });
     this.composeWith(`fountain-gulp:insight`, {options: this.options}, {
       local: require.resolve(`../insight`)
     });

--- a/generators/ci/index.js
+++ b/generators/ci/index.js
@@ -4,7 +4,7 @@ const fountain = require('fountain-generator');
 
 module.exports = fountain.Base.extend({
   writing() {
-    if (this.options.ci === 'jenkins') {
+    if (this.options.ci.includes('jenkins')) {
       this.fs.copy(
         this.templatePath('.dockerignore'),
         this.destinationPath('.dockerignore')
@@ -14,19 +14,19 @@ module.exports = fountain.Base.extend({
         this.destinationPath('Dockerfile')
       );
     }
-    if (this.options.ci === 'travis') {
+    if (this.options.ci.includes('travis')) {
       this.fs.copy(
         this.templatePath('.travis.yml'),
         this.destinationPath('.travis.yml')
       );
     }
-    if (this.options.ci === 'circleci') {
+    if (this.options.ci.includes('circleci')) {
       this.fs.copy(
         this.templatePath('circle.yml'),
         this.destinationPath('circle.yml')
       );
     }
-    if (this.options.ci === 'wercker') {
+    if (this.options.ci.includes('wercker')) {
       this.fs.copy(
         this.templatePath('wercker.yml'),
         this.destinationPath('wercker.yml')

--- a/generators/ci/index.js
+++ b/generators/ci/index.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const fountain = require('fountain-generator');
+
+module.exports = fountain.Base.extend({
+  writing() {
+    if (this.options.ci === 'jenkins') {
+      this.fs.copy(
+        this.templatePath('.dockerignore'),
+        this.destinationPath('.dockerignore')
+      );
+      this.fs.copy(
+        this.templatePath('Dockerfile'),
+        this.destinationPath('Dockerfile')
+      );
+    }
+    if (this.options.ci === 'travis') {
+      this.fs.copy(
+        this.templatePath('.travis.yml'),
+        this.destinationPath('.travis.yml')
+      );
+    }
+    if (this.options.ci === 'circleci') {
+      this.fs.copy(
+        this.templatePath('circle.yml'),
+        this.destinationPath('circle.yml')
+      );
+    }
+    if (this.options.ci === 'wercker') {
+      this.fs.copy(
+        this.templatePath('wercker.yml'),
+        this.destinationPath('wercker.yml')
+      );
+    }
+  }
+});

--- a/generators/ci/templates/.dockerignore
+++ b/generators/ci/templates/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.gitignore
+node_modules

--- a/generators/ci/templates/.travis.yml
+++ b/generators/ci/templates/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - 'stable'

--- a/generators/ci/templates/Dockerfile
+++ b/generators/ci/templates/Dockerfile
@@ -1,0 +1,5 @@
+FROM mhart/alpine-node:6
+WORKDIR /opt/app
+ADD . /opt/app
+RUN npm install
+CMD ["npm","test"]

--- a/generators/ci/templates/circle.yml
+++ b/generators/ci/templates/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 6.2.2

--- a/generators/ci/templates/wercker.yml
+++ b/generators/ci/templates/wercker.yml
@@ -1,0 +1,10 @@
+box: nodesource/trusty
+build:
+  steps:
+    - npm-install
+    - npm-test
+    - script:
+        name: echo nodejs information
+        code: |
+          echo "node version $(node -v) running"
+          echo "npm version $(npm -v) running"

--- a/test/app/index/index.composing.js
+++ b/test/app/index/index.composing.js
@@ -13,14 +13,14 @@ test.before(() => {
   require('../../../generators/app/index');
 });
 
-test('Call this.composeWith 6 times', () => {
-  const spy = chai.spy.on(context, 'composeWith');
-  TestUtils.call(context, 'composing', {js: 'babel'});
-  expect(spy).to.have.been.called.exactly(6);
-});
-
 test('Call this.composeWith 7 times', () => {
   const spy = chai.spy.on(context, 'composeWith');
-  TestUtils.call(context, 'composing', {js: 'typescript'});
+  TestUtils.call(context, 'composing', {js: 'babel'});
   expect(spy).to.have.been.called.exactly(7);
+});
+
+test('Call this.composeWith 8 times', () => {
+  const spy = chai.spy.on(context, 'composeWith');
+  TestUtils.call(context, 'composing', {js: 'typescript'});
+  expect(spy).to.have.been.called.exactly(8);
 });

--- a/test/ci/index.js
+++ b/test/ci/index.js
@@ -18,36 +18,29 @@ test.before(() => {
 });
 
 test('Call this.fs.copy twice for Jenkins', () => {
-  context.options.ci = 'jenkins';
+  context.options.ci = ['jenkins'];
   const spy1 = chai.spy.on(context.fs, 'copy');
   TestUtils.call(context, 'writing');
   expect(spy1).to.have.been.called.twice();
 });
 
 test('Call this.fs.copy twice for CircleCi', () => {
-  context.options.ci = 'circleci';
+  context.options.ci = ['circleci'];
   const spy1 = chai.spy.on(context.fs, 'copy');
   TestUtils.call(context, 'writing');
   expect(spy1).to.have.been.called.once();
 });
 
 test('Call this.fs.copy twice for Travis', () => {
-  context.options.ci = 'travis';
+  context.options.ci = ['travis'];
   const spy1 = chai.spy.on(context.fs, 'copy');
   TestUtils.call(context, 'writing');
   expect(spy1).to.have.been.called.once();
 });
 
 test('Call this.fs.copy twice for Wercker', () => {
-  context.options.ci = 'wercker';
+  context.options.ci = ['wercker'];
   const spy1 = chai.spy.on(context.fs, 'copy');
   TestUtils.call(context, 'writing');
   expect(spy1).to.have.been.called.once();
-});
-
-test('Call this.fs.copy twice for None', () => {
-  context.options.ci = 'none';
-  const spy1 = chai.spy.on(context.fs, 'copy');
-  TestUtils.call(context, 'writing');
-  expect(spy1).to.have.been.called.exactly(0);
 });

--- a/test/ci/index.js
+++ b/test/ci/index.js
@@ -1,0 +1,53 @@
+const test = require('ava');
+const spies = require('chai-spies');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(spies);
+const TestUtils = require('fountain-generator').TestUtils;
+
+let context;
+
+test.before(() => {
+  context = TestUtils.mock('ci');
+  context.templatePath = path => path;
+  context.destinationPath = path => path;
+  context.fs = {
+    copy: () => {}
+  };
+  require('../../generators/ci/index');
+});
+
+test('Call this.fs.copy twice for Jenkins', () => {
+  context.options.ci = 'jenkins';
+  const spy1 = chai.spy.on(context.fs, 'copy');
+  TestUtils.call(context, 'writing');
+  expect(spy1).to.have.been.called.twice();
+});
+
+test('Call this.fs.copy twice for CircleCi', () => {
+  context.options.ci = 'circleci';
+  const spy1 = chai.spy.on(context.fs, 'copy');
+  TestUtils.call(context, 'writing');
+  expect(spy1).to.have.been.called.once();
+});
+
+test('Call this.fs.copy twice for Travis', () => {
+  context.options.ci = 'travis';
+  const spy1 = chai.spy.on(context.fs, 'copy');
+  TestUtils.call(context, 'writing');
+  expect(spy1).to.have.been.called.once();
+});
+
+test('Call this.fs.copy twice for Wercker', () => {
+  context.options.ci = 'wercker';
+  const spy1 = chai.spy.on(context.fs, 'copy');
+  TestUtils.call(context, 'writing');
+  expect(spy1).to.have.been.called.once();
+});
+
+test('Call this.fs.copy twice for None', () => {
+  context.options.ci = 'none';
+  const spy1 = chai.spy.on(context.fs, 'copy');
+  TestUtils.call(context, 'writing');
+  expect(spy1).to.have.been.called.exactly(0);
+});

--- a/test/ci/index.js
+++ b/test/ci/index.js
@@ -24,21 +24,21 @@ test('Call this.fs.copy twice for Jenkins', () => {
   expect(spy1).to.have.been.called.twice();
 });
 
-test('Call this.fs.copy twice for CircleCi', () => {
+test('Call this.fs.copy once for CircleCi', () => {
   context.options.ci = ['circleci'];
   const spy1 = chai.spy.on(context.fs, 'copy');
   TestUtils.call(context, 'writing');
   expect(spy1).to.have.been.called.once();
 });
 
-test('Call this.fs.copy twice for Travis', () => {
+test('Call this.fs.copy once for Travis', () => {
   context.options.ci = ['travis'];
   const spy1 = chai.spy.on(context.fs, 'copy');
   TestUtils.call(context, 'writing');
   expect(spy1).to.have.been.called.once();
 });
 
-test('Call this.fs.copy twice for Wercker', () => {
+test('Call this.fs.copy once for Wercker', () => {
   context.options.ci = ['wercker'];
   const spy1 = chai.spy.on(context.fs, 'copy');
   TestUtils.call(context, 'writing');


### PR DESCRIPTION
I thought it would be useful that Fountain could generate default CI configuration for users.
So, I added prompt to choose which CI : 
-  Travis
- Jenkins (with a docker configuration base on [alpine-nodejs](https://github.com/mhart/alpine-node) image, for a light size)
- Wercker
- Circle-CI

Link to [this PR](https://github.com/FountainJS/fountain-generator/pull/38)
