### PR TITLE
make sure htmlTemplateCache is rebuilt before reloading

### DIFF
--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -36,7 +36,7 @@ function watch(done) {
 <% } -%>
 <% if (framework !== 'react') { -%>
 <%   if (modules !== 'systemjs') { -%>
-  gulp.watch(conf.path.src('app/**/*.html'), reloadBrowserSync);
+  gulp.watch(conf.path.src('app/**/*.html'), gulp.series('partials', reloadBrowserSync));
 <%   } else { -%>
   gulp.watch(conf.path.src('**/*.html'), reloadBrowserSync);
 <%   } -%>


### PR DESCRIPTION
When HTML templates are watched and changed, htmlTemplateCache is not rebuilt correctly before reloading the browser. This fixes the problem ;)
