### PR TITLE
Only watch index.html if using webpack

### DIFF
--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -34,7 +34,7 @@ function watch(done) {
   ], gulp.parallel('inject'));
 
 <% } -%>
-<% if (framework !== 'react') { -%>
+<% if (framework !== 'react' && modules !== 'webpack') { -%>
 <%   if (modules !== 'systemjs') { -%>
   gulp.watch(conf.path.src('app/**/*.html'), reloadBrowserSync);
 <%   } else { -%>


### PR DESCRIPTION
All other templates are caught in the webpack watch so without this the page is reloaded by both the webpack and watch job when editing an html page.
