### PR TITLE
bump useref and sourcemaps, update the way we use them

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -23,12 +23,13 @@ module.exports = fountain.Base.extend({
 
       if (this.options.modules !== 'webpack') {
         Object.assign(pkg.devDependencies, {
-          'gulp-useref': '^3.0.3',
+          'gulp-useref': '^3.1.2',
+          'lazypipe': '^1.0.1',
           'gulp-postcss': '^6.0.1',
           'autoprefixer': '^6.2.3',
           'gulp-rev': '^6.0.1',
           'gulp-rev-replace': '^0.4.2',
-          'gulp-sourcemaps': '^1.6.0',
+          'gulp-sourcemaps': '^2.2.0',
           'gulp-uglify': '^1.4.2',
           'uglify-save-license': '^0.4.1',
           'gulp-cssnano': '^2.1.0',

--- a/generators/app/templates/gulp_tasks/build.js
+++ b/generators/app/templates/gulp_tasks/build.js
@@ -1,6 +1,7 @@
 const gulp = require('gulp');
 const filter = require('gulp-filter');
 const useref = require('gulp-useref');
+const lazypipe = require('lazypipe');
 const rev = require('gulp-rev');
 const revReplace = require('gulp-rev-replace');
 const uglify = require('gulp-uglify');
@@ -37,23 +38,20 @@ function build() {
 <% if (framework === 'angular1' && modules === 'inject') { -%>
     .pipe(inject(partialsInjectFile, partialsInjectOptions))
 <% } -%>
-    .pipe(useref())
+    .pipe(useref({}, lazypipe().pipe(sourcemaps.init, {loadMaps: true})))
     .pipe(jsFilter)
-    .pipe(sourcemaps.init())
 <% if (framework === 'angular1') { -%>
     .pipe(ngAnnotate())
 <% } -%>
     .pipe(uglify({preserveComments: uglifySaveLicense})).on('error', conf.errorHandler('Uglify'))
     .pipe(rev())
-    .pipe(sourcemaps.write('maps'))
     .pipe(jsFilter.restore)
     .pipe(cssFilter)
-    .pipe(sourcemaps.init())
     .pipe(cssnano())
     .pipe(rev())
-    .pipe(sourcemaps.write('maps'))
     .pipe(cssFilter.restore)
     .pipe(revReplace())
+    .pipe(sourcemaps.write('maps'))
     .pipe(htmlFilter)
     .pipe(htmlmin())
     .pipe(htmlFilter.restore)

--- a/test/app/index/index.pkg.js
+++ b/test/app/index/index.pkg.js
@@ -32,12 +32,13 @@ test.beforeEach(() => {
 test('Configuring package.json with angular1/systemjs/css', t => {
   const expected = _.mergeWith({}, pkg, {
     devDependencies: {
-      'gulp-useref': '^3.0.3',
+      'gulp-useref': '^3.1.2',
+      'lazypipe': '^1.0.1',
       'gulp-postcss': '^6.0.1',
       'autoprefixer': '^6.2.3',
       'gulp-rev': '^6.0.1',
       'gulp-rev-replace': '^0.4.2',
-      'gulp-sourcemaps': '^1.6.0',
+      'gulp-sourcemaps': '^2.2.0',
       'gulp-uglify': '^1.4.2',
       'uglify-save-license': '^0.4.1',
       'gulp-cssnano': '^2.1.0',
@@ -79,12 +80,13 @@ test('Configuring package.json with angular2/systemjs/scss', t => {
     devDependencies: {
       'gulp-sass': '^2.1.1',
       'gulp-inline-ng2-template': '^2.0.4',
-      'gulp-useref': '^3.0.3',
+      'gulp-useref': '^3.1.2',
+      'lazypipe': '^1.0.1',
       'gulp-postcss': '^6.0.1',
       'autoprefixer': '^6.2.3',
       'gulp-rev': '^6.0.1',
       'gulp-rev-replace': '^0.4.2',
-      'gulp-sourcemaps': '^1.6.0',
+      'gulp-sourcemaps': '^2.2.0',
       'gulp-uglify': '^1.4.2',
       'uglify-save-license': '^0.4.1',
       'gulp-cssnano': '^2.1.0',


### PR DESCRIPTION
Updates on `gulp-sourcemaps` broke our build with `useref`. According to the documentation, there is the new way for doing it.

Fix https://github.com/FountainJS/generator-fountain-webapp/issues/155