### PR TITLE
spliting other task in other:serve and other:dist to allow serve task…

### DIFF
--- a/generators/app/conf.js
+++ b/generators/app/conf.js
@@ -31,11 +31,11 @@ module.exports = function gulpfileConf(generatorOptions) {
   const options = Object.assign({}, generatorOptions);
 
   if (options.modules === 'webpack') {
-    options.buildTask = series(parallel('other', 'webpack:dist'));
+    options.buildTask = series(parallel('other:dist', 'webpack:dist'));
   } else if (options.modules === 'inject') {
-    options.buildTask = series(parallel('inject', 'other'), 'build');
+    options.buildTask = series(parallel('inject', 'other:dist'), 'build');
   } else {
-    options.buildTask = series(parallel('systemjs', 'systemjs:html', 'styles', 'other'), 'build');
+    options.buildTask = series(parallel('systemjs', 'systemjs:html', 'styles', 'other:dist'), 'build');
   }
 
   if (options.framework === 'angular1' && options.modules !== 'webpack') {

--- a/generators/app/templates/gulp_tasks/misc.js
+++ b/generators/app/templates/gulp_tasks/misc.js
@@ -10,13 +10,14 @@ const rename = require('gulp-rename');
 const conf = require('../conf/gulp.conf');
 
 gulp.task('clean', clean);
-gulp.task('other', other);
+gulp.task('other:serve', otherServe);
+gulp.task('other:dist', otherDist);
 
 function clean() {
   return del([conf.paths.dist, conf.paths.tmp]);
 }
 
-function other() {
+function otherServe() {
   const fileFilter = filter(file => file.stat.isFile());
 <% if (modules === 'systemjs') { -%>
   const jsonFilter = path => {
@@ -34,5 +35,26 @@ function other() {
 <% if (modules === 'systemjs') { -%>
     .pipe(rename(jsonFilter))
 <% } -%>
-    .pipe(gulp.dest(conf.paths.dist));
+    .pipe(gulp.dest(conf.paths.tmp));
+}
+
+function otherDist() {
+  const fileFilter = filter(file => file.stat.isFile());
+<% if (modules === 'systemjs') { -%>
+    const jsonFilter = path => {
+      if (path.extname === '.json') {
+        path.dirname = `$(conf.paths.src)/${path.dirname}`;
+      }
+    };
+  <% } -%>
+
+  return gulp.src([
+      path.join(conf.paths.src, '/**/*'),
+      path.join(`!${conf.paths.src}`, '/**/*.{<%- ignored %>}')
+    ])
+      .pipe(fileFilter)
+    <% if (modules === 'systemjs') { -%>
+  .pipe(rename(jsonFilter))
+    <% } -%>
+.pipe(gulp.dest(conf.paths.dist));
 }

--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -11,7 +11,7 @@ const hub = new HubRegistry([conf.path.tasks('*.js')]);
 gulp.registry(hub);
 
 <% if (modules === 'inject') { -%>
-gulp.task('inject', gulp.series(gulp.parallel('styles', 'scripts'), 'inject'));
+gulp.task('inject', gulp.series(gulp.parallel('other:serve', 'styles', 'scripts'), 'inject'));
 <% } -%>
 gulp.task('build', <%- buildTask %>);
 gulp.task('test', <%- testTask %>);

--- a/test/app/conf/conf.js
+++ b/test/app/conf/conf.js
@@ -6,7 +6,7 @@ test('gulpfileConf with react/webpack', t => {
   const expected = {
     modules: 'webpack',
     framework: 'react',
-    buildTask: `gulp.series(gulp.parallel('other', 'webpack:dist'))`,
+    buildTask: `gulp.series(gulp.parallel('other:dist', 'webpack:dist'))`,
     serveTask: `gulp.series('webpack:watch', 'watch', 'browsersync')`,
     testTask: `gulp.series('karma:single-run')`,
     testAutoTask: `gulp.series('karma:auto-run')`
@@ -19,7 +19,7 @@ test('gulpfileConf with angular1/webpack', t => {
   const expected = {
     modules: 'webpack',
     framework: 'angular1',
-    buildTask: `gulp.series(gulp.parallel('other', 'webpack:dist'))`,
+    buildTask: `gulp.series(gulp.parallel('other:dist', 'webpack:dist'))`,
     serveTask: `gulp.series('webpack:watch', 'watch', 'browsersync')`,
     testTask: `gulp.series('karma:single-run')`,
     testAutoTask: `gulp.series('karma:auto-run')`
@@ -32,7 +32,7 @@ test('gulpfileConf with react/inject', t => {
   const expected = {
     modules: 'inject',
     framework: 'react',
-    buildTask: `gulp.series(gulp.parallel('inject', 'other'), 'build')`,
+    buildTask: `gulp.series(gulp.parallel('inject', 'other:dist'), 'build')`,
     serveTask: `gulp.series('inject', 'watch', 'browsersync')`,
     testTask: `gulp.series('scripts', 'karma:single-run')`,
     testAutoTask: `gulp.series('watch', 'karma:auto-run')`
@@ -45,7 +45,7 @@ test('gulpfileConf with react/systemjs', t => {
   const expected = {
     modules: 'systemjs',
     framework: 'react',
-    buildTask: `gulp.series(gulp.parallel('systemjs', 'systemjs:html', 'styles', 'other'), 'build')`,
+    buildTask: `gulp.series(gulp.parallel('systemjs', 'systemjs:html', 'styles', 'other:dist'), 'build')`,
     serveTask: `gulp.series(gulp.parallel('scripts', 'styles'), 'watch', 'browsersync')`,
     testTask: `gulp.series('karma:single-run')`,
     testAutoTask: `gulp.series('karma:auto-run')`


### PR DESCRIPTION
… to handle properly src/assets/

Fix https://github.com/FountainJS/generator-fountain-gulp/issues/64
